### PR TITLE
Fix autoupdate, Ruffle command line and JS API usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
           "com.ruffle.power-mode": {
             "title": "Power Mode",
             "type": "string",
-            "default": "High",
+            "default": "high",
             "enum": [
-              "High",
-              "Low"
+              "high",
+              "low"
             ],
             "description": "Power preference for the graphics device used. High power usage tends to prefer dedicated GPUs, whereas a low power usage tends prefer integrated GPUs."
           },
@@ -28,11 +28,11 @@
             "description": "Type of graphics backend to use. Not all options may be supported by your current system. Default will attempt to pick the most supported graphics backend.",
             "default": "default",
             "enum": [
-              "Default",
-              "Vulkan",
-              "Metal",
-              "Dx12",
-              "Dx11"
+              "default",
+              "vulkan",
+              "metal",
+              "dx12",
+              "dx11"
             ]
           }
         }
@@ -88,6 +88,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
+    "arch": "^2.2.0",
     "axios": "^0.20.0"
   }
 }

--- a/src/ext.ts
+++ b/src/ext.ts
@@ -2,7 +2,7 @@ import * as flashpoint from 'flashpoint-launcher';
 import * as fs from 'fs';
 import * as path from 'path';
 import axios from 'axios';
-import { fips } from 'crypto';
+import arch from 'arch';
 
 type AssetFile = {
   name: string;
@@ -88,7 +88,9 @@ export async function activate(context: flashpoint.ExtensionContext) {
   };
 
   const downloadRuffleStandalone = async (assetFile: AssetFile, logDev: (text: string) => void) => {
-    fs.rmdirSync(ruffleStandaloneDir, { recursive: true });
+    if (fs.existsSync(ruffleStandaloneDir)) {
+      fs.rmdirSync(ruffleStandaloneDir, { recursive: true });
+    }
     await fs.promises.mkdir(ruffleStandaloneDir)
     const filePath = path.join(ruffleStandaloneDir, assetFile.name);
     logDev(`Found Asset \n  Name: ${assetFile.name}\n  Url: ${assetFile.url}`);
@@ -106,7 +108,9 @@ export async function activate(context: flashpoint.ExtensionContext) {
   };
 
   const downloadRuffleWeb = async (assetFile: AssetFile, logDev: (text: string) => void) => {
-    fs.rmdirSync(ruffleWebDir, { recursive: true });
+    if (fs.existsSync(ruffleWebDir)) {
+      fs.rmdirSync(ruffleWebDir, { recursive: true });
+    }
     await fs.promises.mkdir(ruffleWebDir)
     const filePath = path.join(ruffleWebDir, assetFile.name);
     logDev(`Found Asset \n  Name: ${assetFile.name}\n  Url: ${assetFile.url}`);
@@ -222,11 +226,14 @@ function dataPrintFactory(logFunc: (val: string) => void) {
 function getPlatformRegex(): RegExp {
   switch (process.platform) {
     case 'win32':
-      return /.*windows\.zip/;
+      switch (arch()) {
+        case 'x64': return /.*windows-x86_64\.zip/;
+        case 'x86': return /.*windows-x86_32\.zip/;
+      }
     case 'linux':
-      return /.*linux\.tar\.gz/;
+      return /.*linux-x86_64\.tar\.gz/;
     case 'darwin':
-      return /.*osx\.tar\.gz/;
+      return /.*macos-universal\.tar\.gz/;
     default:
       throw new Error('Operating System not supported by Ruffle.');
   }

--- a/static/ruffle.html
+++ b/static/ruffle.html
@@ -6,13 +6,32 @@
       window.RufflePlayer = window.RufflePlayer || {};
 
       window.addEventListener('DOMContentLoaded', () => {
+        const container = document.getElementById('container');
         const urlParams = new URLSearchParams(window.location.search);
-        const data = urlParams.get('data');
-        let ruffle = window.RufflePlayer.newest();
-        let player = ruffle.create_player();
-        let container = document.getElementById('container');
-        container.appendChild(player);
-        player.stream_swf_url(data);
+        const launchUrl = urlParams.get('data');
+        const launchPath = (new URL(launchUrl)).pathname;
+        let baseTag = document.createElement('base');
+        baseTag.setAttribute('href', launchUrl);
+        document.head.appendChild(baseTag);
+        if (launchPath.endsWith('.swf')) {
+          let ruffle = window.RufflePlayer.newest();
+          let player = ruffle.createPlayer();
+          player.config = {"letterbox": "on"};
+          container.appendChild(player);
+          player.load(launchUrl);
+          player.addEventListener('loadedmetadata', () => {
+            player.style.width  = Math.max(640, player.metadata.width) + 'px';
+            player.style.height = Math.max(480, player.metadata.height) + 'px';
+          });
+        } else {
+          fetch(launchUrl).then(function(response) {
+            return response.text();
+          }).then(function (responseText) {
+            container.innerHTML = responseText;
+          }).catch(function (err) {
+            container.innerHTML = err;
+          });
+        }
       });
     </script>
   </head>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "./dist",
+    "esModuleInterop": true
   },
   "exclude": [
     "./dist"


### PR DESCRIPTION
- Fix regex for finding the latest desktop builds for each platform
- Use `arch` library to choose between 32-bit and 64-bit Ruffle builds on Windows. (Same arch library as used in https://github.com/FlashpointProject/FPL-Analytics/pull/2)
- When updating Ruffle, don't try to delete nonexistent folders (it was causing an error)
- Fix capitalization of command-line options passed to the Ruffle executable
- Use the latest Ruffle JavaScript API functions and size the player dynamically according to the SWF metadata (see https://github.com/Dri0m/9o3o/blob/master/static/main.js#L56)
- Add support for loading HTML inside the `:ruffle-web:` application. Ruffle will polyfill any object/embed elements inside the loaded HTML. Note that scripts in the loaded HTML will not execute - [this is a browser limitation](https://www.danielcrabtree.com/blog/25/gotchas-with-dynamically-adding-script-tags-to-html).